### PR TITLE
Don't rely on resource_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backbone Tastypie [![Build Status](https://secure.travis-ci.org/amccloud/backbone-tastypie.png)](http://travis-ci.org/amccloud/backbone-tastypie]) #
+# Backbone Tastypie [![Build Status](https://secure.travis-ci.org/boronine/backbone-tastypie.png)](http://travis-ci.org/boronine/backbone-tastypie) #
 Modifications to Backbone's Model an Collection so that they play nice with django-tastypie. Includes a way to easily paginate over a resource list and a way to access the associated meta information.
 
 ## Example ##

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backbone Tastypie [![Build Status](https://secure.travis-ci.org/boronine/backbone-tastypie.png)](http://travis-ci.org/boronine/backbone-tastypie) #
+# Backbone Tastypie [![Build Status](https://secure.travis-ci.org/amccloud/backbone-tastypie.png)](http://travis-ci.org/amccloud/backbone-tastypie]) #
 Modifications to Backbone's Model an Collection so that they play nice with django-tastypie. Includes a way to easily paginate over a resource list and a way to access the associated meta information.
 
 ## Example ##

--- a/backbone-tastypie.js
+++ b/backbone-tastypie.js
@@ -11,7 +11,7 @@
             if (this.isNew())
                 return url;
 
-            return url + this.get('id');
+            return url + this.get('id') + '/';
         }
 
     });

--- a/backbone-tastypie.js
+++ b/backbone-tastypie.js
@@ -4,7 +4,6 @@
     };
 
     Backbone.Tastypie.Model = Backbone.Model.extend({
-        idAttribute: 'resource_uri',
 
         url: function() {
             var url = getValue(this, 'urlRoot') || getValue(this.collection, 'urlRoot') || urlError();
@@ -12,14 +11,9 @@
             if (this.isNew())
                 return url;
 
-            return this.get('resource_uri');
-        },
-        _getId: function() {
-            if (this.has('id'))
-                return this.get('id');
-
-            return _.chain(this.get('resource_uri').split('/')).compact().last().value();
+            return url + this.get('id');
         }
+
     });
 
     Backbone.Tastypie.Collection = Backbone.Collection.extend({

--- a/backbone-tastypie.js
+++ b/backbone-tastypie.js
@@ -34,7 +34,7 @@
 
             if (models) {
                 var ids = _.map(models, function(model) {
-                    return model._getId();
+                    return model.get('id');
                 });
 
                 url += 'set/' + ids.join(';') + '/';


### PR DESCRIPTION
I had a problem when I was [bootstrapping my models](http://backbonejs.org/#FAQ-bootstrap). These models had `id`'s loaded directly from Django, but Bootstrap's `isNew` was returning `true`.

In my fork I got rid of `resource_uri` entirely, the model's id is now `id` and `url` is calculated from `id` and `rootUrl`.
